### PR TITLE
modify getWord route to return only word and not it's database id

### DIFF
--- a/controllers/api/word-routes.js
+++ b/controllers/api/word-routes.js
@@ -9,7 +9,7 @@ router.get('/getWord', async (req, res) => {
         const currentWord = await Words.findOne({ 
             order: sequelize.literal('rand()')
         });
-        res.status(200).json(currentWord);
+        res.status(200).json(currentWord.word);
         
     } catch (err) {
         console.log(err);


### PR DESCRIPTION
Previously /api/words/getWord response contained the database id as well as the word. The id was not needed so code was modified to return only the word

BEFORE:
![Screen Shot 2022-02-18 at 7 24 42 PM](https://user-images.githubusercontent.com/90160720/154777836-273aa1c7-8ca4-44bf-b04a-849da106d135.png)

AFTER:
![Screen Shot 2022-02-18 at 7 24 13 PM](https://user-images.githubusercontent.com/90160720/154777852-76659501-cb2b-48d9-b1f6-69afec07b7f1.png)

